### PR TITLE
Refresh Qira portal with a light customer theme

### DIFF
--- a/Agents/AOAI-Model-Migration-Benchmark/qira-live-benchmark-console/README-CN.md
+++ b/Agents/AOAI-Model-Migration-Benchmark/qira-live-benchmark-console/README-CN.md
@@ -134,6 +134,9 @@ Work VM 上端口明确错开：`8513` 是 Portal，`8514` 是反向隧道。Por
 必须在 `QIRA_ALLOWED_ORIGIN` 中明确列出实际使用的 HTTP 和/或 HTTPS 浏览器 Origin；
 服务端绝不根据请求的 `Host` header 推导允许来源。
 
+`deploy/demo-portal-card.html` 是 Linux Work VM Demo Portal 的标准卡片。新安装时应将
+其放在 Portal 网格第一位，并同步增加 active-service 计数。
+
 ### 在笔记本上、没有凭据时
 
 照样可以启动：
@@ -223,7 +226,8 @@ python server.py --port 8080
 |---|---|
 | `server.py` | 纯标准库 HTTP 服务、SSE 事件流、CSV 导出 |
 | `bench_core.py` | 加载研究 harness；计划、执行、聚合 |
-| `static/` | 界面：一个 HTML、一个样式表、一个零依赖 JS |
+| `static/` | 响应式暖色浅色界面并自动适配深色；零依赖 HTML/CSS/JS 与 SVG 图表 |
+| `deploy/demo-portal-card.html` | Linux Work VM Demo Portal 第一张卡片的标准注册片段 |
 | `scripts/build_replay_pack.py` | 重建 `replay/replay_pack.json`；`--check` 做校验 |
 | `replay/replay_pack.json` | 已记录的研究运行，用于无凭据演示 |
 | `history/` | 每次跑完的运行一个 JSON；已 git 忽略，首次运行时自动创建 |

--- a/Agents/AOAI-Model-Migration-Benchmark/qira-live-benchmark-console/README.md
+++ b/Agents/AOAI-Model-Migration-Benchmark/qira-live-benchmark-console/README.md
@@ -154,6 +154,10 @@ units. In particular, `portal.env` must list the exact HTTP and/or HTTPS
 browser origins in `QIRA_ALLOWED_ORIGIN`; the server never trusts the request's
 `Host` header to establish an allowed origin.
 
+`deploy/demo-portal-card.html` is the canonical card for the Linux Work VM
+Demo Portal. Keep it as the first card in the portal grid and increment the
+portal's active-service count when registering a fresh installation.
+
 ### On a laptop, with no credentials
 
 Start it anyway:
@@ -266,7 +270,8 @@ comparable too.
 |---|---|
 | `server.py` | Standard-library HTTP server, SSE event stream, CSV export |
 | `bench_core.py` | Loads the study harness; planning, execution, aggregation |
-| `static/` | The UI: one HTML file, one stylesheet, one dependency-free JS file |
+| `static/` | Responsive warm-light UI with dark-mode adaptation; dependency-free HTML/CSS/JS and SVG charts |
+| `deploy/demo-portal-card.html` | Canonical first-card registration for the Linux Work VM Demo Portal |
 | `scripts/build_replay_pack.py` | Rebuilds `replay/replay_pack.json`; `--check` verifies it |
 | `replay/replay_pack.json` | Recorded study runs for credential-free demonstration |
 | `history/` | One JSON per completed run; git-ignored, created on first run |

--- a/Agents/AOAI-Model-Migration-Benchmark/qira-live-benchmark-console/deploy/demo-portal-card.html
+++ b/Agents/AOAI-Model-Migration-Benchmark/qira-live-benchmark-console/deploy/demo-portal-card.html
@@ -1,0 +1,31 @@
+<!-- Insert inside the Demo Portal .grid container. -->
+<!-- QIRA_BENCHMARK_CARD -->
+<div class="card red-l">
+  <div class="card-top">
+    <div class="card-icon bg-red">📊</div>
+    <div class="card-name">
+      <a href="http://linuxworkvm1-work.eastasia.cloudapp.azure.com/qira-benchmark/?clawpilotTheme=light" target="_blank">
+        Qira Live Model Benchmark
+      </a>
+    </div>
+    <span class="port-badge">:8513 · proxy</span>
+    <span class="status-dot on"></span>
+  </div>
+  <div class="card-desc">
+    Lenovo Qira live model comparison: 3 candidates × reasoning-effort matrix ×
+    6 Qira scenarios. Live TTFT, TPOT, tokens/sec, token usage, session cost,
+    charts, saved history and recorded report runs. No web search or tools;
+    measurement executes on the Sweden Central runner.
+  </div>
+  <div class="card-footer">
+    <span class="auth-tag">🔑 lenovo-qira / qira2026</span>
+    <a class="src-btn"
+       href="https://github.com/david-xinyuwei/david-share/tree/master/Agents/AOAI-Model-Migration-Benchmark/qira-live-benchmark-console"
+       target="_blank"
+       title="Source code (public)">Source</a>
+    <a class="open-btn"
+       href="http://linuxworkvm1-work.eastasia.cloudapp.azure.com/qira-benchmark/?clawpilotTheme=light"
+       target="_blank">Open →</a>
+  </div>
+</div>
+<!-- /QIRA_BENCHMARK_CARD -->

--- a/Agents/AOAI-Model-Migration-Benchmark/qira-live-benchmark-console/static/app.js
+++ b/Agents/AOAI-Model-Migration-Benchmark/qira-live-benchmark-console/static/app.js
@@ -7,7 +7,10 @@
  */
 'use strict';
 
-const PALETTE = ['#4da3ff', '#3ddc97', '#ffb454', '#ff6b6b', '#b07cff', '#5ad1e6', '#f78fb3', '#9ad14b'];
+const PALETTE = [
+  '--cp-accent', '--cp-success', '--cp-warning', '--cp-danger',
+  '--cp-link', '--cp-text-soft', '--cp-border-strong', '--cp-text-muted'
+];
 const APP_BASE = location.pathname.replace(/\/(?:index\.html)?$/, '');
 const apiUrl = (path) => APP_BASE + path;
 
@@ -27,12 +30,14 @@ const state = {
 };
 
 const $ = (id) => document.getElementById(id);
+const themeColor = (token) =>
+  getComputedStyle(document.documentElement).getPropertyValue(token).trim();
 
 // ---------------------------------------------------------------- utilities
 
 function colorFor(name) {
   if (!state.colors.has(name)) {
-    state.colors.set(name, PALETTE[state.colors.size % PALETTE.length]);
+    state.colors.set(name, themeColor(PALETTE[state.colors.size % PALETTE.length]));
   }
   return state.colors.get(name);
 }
@@ -131,11 +136,11 @@ function axes(svg, geo, ticks, formatter) {
     const y = top + height - (t / max) * height;
     svg.appendChild(el('line', {
       x1: left, x2: left + width, y1: y, y2: y,
-      stroke: '#2a3547', 'stroke-width': 1
+      stroke: themeColor('--cp-border'), 'stroke-width': 1
     }));
     svg.appendChild(el('text', {
       x: left - 8, y: y + 4, 'text-anchor': 'end',
-      fill: '#93a3bb', 'font-size': 10
+      fill: themeColor('--cp-text-muted'), 'font-size': 10
     }, formatter ? formatter(t) : fmt(t)));
   });
   return max;
@@ -147,7 +152,7 @@ function xLabels(svg, geo, labels, bandWidth) {
     const x = left + bandWidth * (i + 0.5);
     const text = el('text', {
       x, y: top + height + 14, 'text-anchor': 'end',
-      fill: '#93a3bb', 'font-size': 10,
+      fill: themeColor('--cp-text-muted'), 'font-size': 10,
       transform: `rotate(-28 ${x} ${top + height + 14})`
     }, shortLabel(label));
     text.appendChild(el('title', {}, label));
@@ -197,7 +202,7 @@ function groupedBars(container, labels, series, formatter) {
       if (series.length <= 2 && barW > 22) {
         svg.appendChild(el('text', {
           x: x + barW / 2 - 1, y: geo.top + geo.height - h - 4,
-          'text-anchor': 'middle', fill: '#93a3bb', 'font-size': 9
+          'text-anchor': 'middle', fill: themeColor('--cp-text-muted'), 'font-size': 9
         }, formatter ? formatter(value) : fmt(value)));
       }
     });
@@ -205,7 +210,7 @@ function groupedBars(container, labels, series, formatter) {
 
   svg.appendChild(el('line', {
     x1: geo.left, x2: geo.left + geo.width, y1: geo.top + geo.height, y2: geo.top + geo.height,
-    stroke: '#2a3547'
+    stroke: themeColor('--cp-border')
   }));
   xLabels(svg, geo, labels, band);
   if (series.length > 1) legend(container, series.map((s) => ({ label: s.name, color: s.color })));
@@ -242,7 +247,7 @@ function stackedBars(container, labels, series, formatter) {
 
   svg.appendChild(el('line', {
     x1: geo.left, x2: geo.left + geo.width, y1: geo.top + geo.height, y2: geo.top + geo.height,
-    stroke: '#2a3547'
+    stroke: themeColor('--cp-border')
   }));
   xLabels(svg, geo, labels, band);
   legend(container, series.map((s) => ({ label: s.name, color: s.color })));
@@ -275,11 +280,11 @@ function scatter(container, points, xLabel, yLabel) {
     if (px(v) < geo.left - 1 || px(v) > geo.left + geo.width + 1) continue;
     svg.appendChild(el('line', {
       x1: px(v), x2: px(v), y1: geo.top, y2: geo.top + geo.height,
-      stroke: '#2a3547', 'stroke-dasharray': '2 3'
+      stroke: themeColor('--cp-border'), 'stroke-dasharray': '2 3'
     }));
     svg.appendChild(el('text', {
       x: px(v), y: geo.top + geo.height + 14, 'text-anchor': 'middle',
-      fill: '#93a3bb', 'font-size': 10
+      fill: themeColor('--cp-text-muted'), 'font-size': 10
     }, fmtMoney(v)));
   }
 
@@ -290,7 +295,7 @@ function scatter(container, points, xLabel, yLabel) {
     const cx = px(p.x), cy = py(p.y);
     const circle = el('circle', {
       cx, cy, r, fill: colorFor(p.label), opacity: .75,
-      stroke: '#0f1420', 'stroke-width': 1.5
+      stroke: themeColor('--cp-surface'), 'stroke-width': 1.5
     });
     circle.appendChild(el('title', {},
       `${p.label}\n${xLabel}: ${fmtMoney(p.x)}\n${yLabel}: ${fmt(p.y)} ms\nmean output: ${fmt(p.size)} tokens`));
@@ -308,7 +313,7 @@ function scatter(container, points, xLabel, yLabel) {
       if (!clash) {
         placed.push(box);
         svg.appendChild(el('text', {
-          x: cx, y, 'text-anchor': 'middle', fill: '#e6ecf5', 'font-size': 9
+          x: cx, y, 'text-anchor': 'middle', fill: themeColor('--cp-text'), 'font-size': 9
         }, text));
         break;
       }
@@ -317,11 +322,11 @@ function scatter(container, points, xLabel, yLabel) {
 
   svg.appendChild(el('text', {
     x: geo.left + geo.width / 2, y: H - 6, 'text-anchor': 'middle',
-    fill: '#93a3bb', 'font-size': 10
+    fill: themeColor('--cp-text-muted'), 'font-size': 10
   }, xLabel + ' (log scale)'));
   svg.appendChild(el('text', {
     x: 12, y: geo.top + geo.height / 2, 'text-anchor': 'middle',
-    fill: '#93a3bb', 'font-size': 10,
+    fill: themeColor('--cp-text-muted'), 'font-size': 10,
     transform: `rotate(-90 12 ${geo.top + geo.height / 2})`
   }, yLabel));
 }
@@ -333,12 +338,12 @@ function renderCharts() {
   const labels = rows.map((s) => s.arm);
 
   groupedBars($('chartTtft'), labels, [
-    { name: 'p50', values: rows.map((s) => s.ttft_p50_ms), color: '#4da3ff' },
-    { name: 'p90', values: rows.map((s) => s.ttft_p90_ms), color: '#24557f' }
+    { name: 'p50', values: rows.map((s) => s.ttft_p50_ms), color: themeColor('--cp-accent') },
+    { name: 'p90', values: rows.map((s) => s.ttft_p90_ms), color: themeColor('--cp-link') }
   ], (v) => fmt(v) + ' ms');
 
   groupedBars($('chartTps'), labels, [
-    { name: 'p50 tok/s', values: rows.map((s) => s.decode_tps_p50), color: '#3ddc97' }
+    { name: 'p50 tok/s', values: rows.map((s) => s.decode_tps_p50), color: themeColor('--cp-success') }
   ], (v) => fmt(v, 1));
   const burstOnly = rows.filter((s) => s.paced_n === 0 && s.bursts > 0);
   const partial = rows.filter((s) => s.paced_n > 0 && s.bursts > 0);
@@ -361,7 +366,7 @@ function renderCharts() {
   const priced = rows.filter((s) => s.cost_per_1k_requests !== null);
   if (priced.length) {
     groupedBars($('chartCost'), priced.map((s) => s.arm), [
-      { name: 'USD / 1k requests', values: priced.map((s) => s.cost_per_1k_requests), color: '#ffb454' }
+      { name: 'USD / 1k requests', values: priced.map((s) => s.cost_per_1k_requests), color: themeColor('--cp-warning') }
     ], (v) => fmtMoney(v));
   } else {
     emptyChart($('chartCost'), 'No arm in this run has confirmed list pricing.');
@@ -375,9 +380,9 @@ function renderCharts() {
   })), 'USD per 1,000 requests', 'TTFT p50');
 
   stackedBars($('chartTokens'), labels, [
-    { name: 'prompt', values: rows.map((s) => s.prompt_tokens_mean || 0), color: '#33507a' },
-    { name: 'reasoning (billed, hidden)', values: rows.map((s) => s.reasoning_tokens_mean || 0), color: '#b07cff' },
-    { name: 'emitted text', values: rows.map((s) => s.emitted_tokens_mean || 0), color: '#3ddc97' }
+    { name: 'prompt', values: rows.map((s) => s.prompt_tokens_mean || 0), color: themeColor('--cp-link') },
+    { name: 'reasoning (billed, hidden)', values: rows.map((s) => s.reasoning_tokens_mean || 0), color: themeColor('--cp-accent') },
+    { name: 'emitted text', values: rows.map((s) => s.emitted_tokens_mean || 0), color: themeColor('--cp-success') }
   ], (v) => fmt(v));
 
   renderRouter(rows);
@@ -394,7 +399,7 @@ function renderRouter(rows) {
   const models = [...new Set(routed.flatMap((s) => Object.keys(s.served_split)))].sort();
   const series = models.map((m, i) => ({
     name: m,
-    color: PALETTE[i % PALETTE.length],
+    color: themeColor(PALETTE[i % PALETTE.length]),
     values: routed.map((s) => {
       const total = Object.values(s.served_split).reduce((a, b) => a + b, 0) || 1;
       return ((s.served_split[m] || 0) / total) * 100;
@@ -665,7 +670,7 @@ function updateEstimate() {
   const limit = state.catalog?.limits?.max_requests ?? 400;
   const over = total > limit;
   $('estimate').innerHTML = over
-    ? `<b style="color:#ff6b6b">${total} requests</b> exceeds the ${limit}-request cap for one run. Reduce prompts, arms or iterations.`
+    ? `<b class="estimate-error">${total} requests</b> exceeds the ${limit}-request cap for one run. Reduce prompts, arms or iterations.`
     : `<b>${total}</b> requests (${measured} measured${warmup ? ` + ${total - measured} warm-up` : ''}) across <b>${arms}</b> arm(s) &times; <b>${items}</b> prompt(s).`;
   $('runBtn').disabled = over || !arms || !items || state.runId !== null
     || state.catalog?.mode !== 'live';

--- a/Agents/AOAI-Model-Migration-Benchmark/qira-live-benchmark-console/static/index.html
+++ b/Agents/AOAI-Model-Migration-Benchmark/qira-live-benchmark-console/static/index.html
@@ -4,12 +4,22 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Qira live model benchmark console</title>
+<script>
+  (() => {
+    const param = new URLSearchParams(window.location.search).get("clawpilotTheme");
+    const theme =
+      param || (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
+    document.documentElement.setAttribute("data-theme", theme);
+  })();
+</script>
 <link rel="stylesheet" href="static/styles.css">
 </head>
 <body>
 
 <header>
-  <div>
+  <div class="brand-mark" aria-hidden="true">Q</div>
+  <div class="brand-copy">
+    <div class="eyebrow">Microsoft Foundry · native model evaluation</div>
     <h1>Qira live model benchmark console</h1>
     <div class="sub">TTFT / TPOT / tokens per second / cost, measured live on the deployments themselves</div>
   </div>

--- a/Agents/AOAI-Model-Migration-Benchmark/qira-live-benchmark-console/static/styles.css
+++ b/Agents/AOAI-Model-Migration-Benchmark/qira-live-benchmark-console/static/styles.css
@@ -1,272 +1,724 @@
 :root {
-  --bg: #0f1420;
-  --panel: #161d2c;
-  --panel-2: #1d2637;
-  --line: #2a3547;
-  --text: #e6ecf5;
-  --muted: #93a3bb;
-  --accent: #4da3ff;
-  --ok: #3ddc97;
-  --warn: #ffb454;
-  --bad: #ff6b6b;
-  --router: #b07cff;
-  --font: -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Microsoft YaHei", sans-serif;
-  --mono: "Cascadia Mono", Consolas, "SF Mono", Menlo, monospace;
+  color-scheme: light;
+  --cp-bg: #f7f4ef;
+  --cp-bg-elevated: #fcfbf8;
+  --cp-surface: #ffffff;
+  --cp-surface-soft: #f5f5f5;
+  --cp-border: #dedede;
+  --cp-border-strong: #919191;
+  --cp-text: #242424;
+  --cp-text-muted: #5c5c5c;
+  --cp-text-soft: #6f6f6f;
+  --cp-accent: #b11f4b;
+  --cp-accent-hover: #9a1a41;
+  --cp-accent-soft: rgba(177, 31, 75, 0.08);
+  --cp-accent-fg: #ffffff;
+  --cp-success: #16a34a;
+  --cp-danger: #dc2626;
+  --cp-warning: #f59e0b;
+  --cp-link: #0078d4;
+  --cp-shadow: 0 18px 48px rgba(0, 0, 0, 0.12);
+  --cp-overlay: rgba(255, 255, 255, 0.8);
+  --cp-panel: rgba(255, 255, 255, 0.86);
+  --cp-panel-strong: rgba(255, 255, 255, 0.96);
+  --cp-sheen: rgba(255, 255, 255, 0.55);
+  --cp-highlight: rgba(177, 31, 75, 0.12);
+}
+html[data-theme="dark"] {
+  color-scheme: dark;
+  --cp-bg: #3d3b3a;
+  --cp-bg-elevated: #343231;
+  --cp-surface: #292929;
+  --cp-surface-soft: #2e2e2e;
+  --cp-border: #474747;
+  --cp-border-strong: #5f5f5f;
+  --cp-text: #dedede;
+  --cp-text-muted: #919191;
+  --cp-text-soft: #b0b0b0;
+  --cp-accent: #fd8ea1;
+  --cp-accent-hover: #fb7b91;
+  --cp-accent-soft: rgba(253, 142, 161, 0.14);
+  --cp-accent-fg: #1a1a1a;
+  --cp-success: #4ade80;
+  --cp-danger: #f87171;
+  --cp-warning: #fbbf24;
+  --cp-link: #4da6ff;
+  --cp-shadow: 0 18px 48px rgba(0, 0, 0, 0.32);
+  --cp-overlay: rgba(41, 41, 41, 0.88);
+  --cp-panel: rgba(41, 41, 41, 0.72);
+  --cp-panel-strong: rgba(41, 41, 41, 0.96);
+  --cp-sheen: rgba(255, 255, 255, 0.04);
+  --cp-highlight: rgba(253, 142, 161, 0.12);
 }
 
-* { box-sizing: border-box; }
+* {
+  box-sizing: border-box;
+}
+
+html {
+  min-height: 100%;
+  background: var(--cp-bg);
+}
 
 body {
+  min-height: 100vh;
   margin: 0;
-  background: var(--bg);
-  color: var(--text);
-  font-family: var(--font);
+  background: var(--cp-bg);
+  color: var(--cp-text);
+  font-family: "Segoe UI", Aptos, Calibri, -apple-system, BlinkMacSystemFont, sans-serif;
   font-size: 14px;
   line-height: 1.5;
 }
 
 header {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 14px 20px;
-  background: var(--panel);
-  border-bottom: 1px solid var(--line);
   position: sticky;
   top: 0;
   z-index: 20;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  min-height: 72px;
+  padding: 12px 24px;
+  background: var(--cp-panel-strong);
+  border-bottom: 1px solid var(--cp-border);
+  box-shadow: 0 1px 2px var(--cp-border);
 }
 
-header h1 { font-size: 16px; margin: 0; font-weight: 600; }
-header .sub { color: var(--muted); font-size: 12px; }
-header .spacer { flex: 1; }
+.brand-mark {
+  display: grid;
+  flex: 0 0 38px;
+  width: 38px;
+  height: 38px;
+  place-items: center;
+  border-radius: 0.625rem;
+  background: var(--cp-accent);
+  color: var(--cp-accent-fg);
+  font-size: 19px;
+  font-weight: 750;
+  letter-spacing: -0.04em;
+}
+
+.brand-copy {
+  min-width: 0;
+}
+
+.eyebrow {
+  margin-bottom: 1px;
+  color: var(--cp-accent);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+header h1 {
+  margin: 0;
+  font-size: 17px;
+  font-weight: 650;
+  letter-spacing: -0.015em;
+}
+
+header .sub {
+  color: var(--cp-text-muted);
+  font-size: 11px;
+}
+
+header .spacer {
+  flex: 1;
+}
 
 .badge {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 3px 9px;
+  padding: 4px 9px;
+  border: 1px solid var(--cp-border);
   border-radius: 999px;
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: .02em;
-  border: 1px solid var(--line);
-  background: var(--panel-2);
-  color: var(--muted);
+  background: var(--cp-surface-soft);
+  color: var(--cp-text-muted);
+  font-size: 10px;
+  font-weight: 650;
+  letter-spacing: 0.02em;
   white-space: nowrap;
 }
-.badge.live { color: #0c1a10; background: var(--ok); border-color: var(--ok); }
-.badge.replay { color: #1a1405; background: var(--warn); border-color: var(--warn); }
-.badge.guard { color: var(--accent); border-color: #24456b; background: #12243a; }
+
+.badge.live {
+  border-color: var(--cp-success);
+  background: var(--cp-surface);
+  color: var(--cp-success);
+}
+
+.badge.replay {
+  border-color: var(--cp-warning);
+  background: var(--cp-surface);
+  color: var(--cp-warning);
+}
+
+.badge.guard {
+  border-color: var(--cp-accent);
+  background: var(--cp-accent-soft);
+  color: var(--cp-accent);
+}
 
 main {
   display: grid;
-  grid-template-columns: 340px 1fr;
-  gap: 16px;
-  padding: 16px;
+  grid-template-columns: 360px minmax(0, 1fr);
+  gap: 18px;
+  width: 100%;
+  max-width: 1800px;
+  margin: 0 auto;
+  padding: 18px;
   align-items: start;
 }
 
 @media (max-width: 1100px) {
-  main { grid-template-columns: 1fr; }
+  header {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  header .spacer {
+    display: none;
+  }
+
+  main {
+    grid-template-columns: 1fr;
+  }
+
+  .setup {
+    position: static;
+    max-height: none;
+  }
+}
+
+.panel,
+.chart {
+  background: var(--cp-surface);
+  border: 1px solid var(--cp-border);
+  border-radius: 16px;
+  box-shadow: 0 1px 2px var(--cp-border);
 }
 
 .panel {
-  background: var(--panel);
-  border: 1px solid var(--line);
-  border-radius: 10px;
-  padding: 14px;
+  padding: 16px;
 }
 
 .panel h2 {
-  font-size: 12px;
+  margin: 0 0 12px;
+  color: var(--cp-text-muted);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
-  letter-spacing: .08em;
-  color: var(--muted);
-  margin: 0 0 10px;
-  font-weight: 600;
 }
 
-.setup { position: sticky; top: 74px; max-height: calc(100vh - 92px); overflow-y: auto; }
+.setup {
+  position: sticky;
+  top: 90px;
+  max-height: calc(100vh - 108px);
+  overflow-y: auto;
+  scrollbar-color: var(--cp-border-strong) var(--cp-surface-soft);
+}
 
 fieldset {
-  border: none;
-  padding: 0;
   margin: 0 0 16px;
+  padding: 0;
+  border: 0;
 }
 
 .group-title {
-  font-size: 11px;
-  text-transform: uppercase;
-  letter-spacing: .06em;
-  color: var(--muted);
-  margin: 12px 0 6px;
   display: flex;
   align-items: center;
   gap: 8px;
+  margin: 14px 0 7px;
+  color: var(--cp-text-muted);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
 }
-.group-title .mini { text-transform: none; letter-spacing: 0; }
+
+.group-title .mini {
+  letter-spacing: 0;
+  text-transform: none;
+}
 
 .opt {
   display: flex;
   align-items: flex-start;
-  gap: 8px;
-  padding: 6px 8px;
-  border-radius: 6px;
-  cursor: pointer;
+  gap: 9px;
+  margin-bottom: 4px;
+  padding: 8px 9px;
   border: 1px solid transparent;
+  border-radius: 0.625rem;
+  cursor: pointer;
+  transition: border-color 120ms ease, background-color 120ms ease;
 }
-.opt:hover { background: var(--panel-2); }
-.opt.on { background: var(--panel-2); border-color: #30507a; }
-.opt input { margin-top: 3px; accent-color: var(--accent); }
-.opt .name { font-weight: 600; font-size: 13px; word-break: break-all; }
-.opt .meta { color: var(--muted); font-size: 11px; }
-.opt .body { flex: 1; min-width: 0; }
-.opt.router .name { color: var(--router); }
 
-select, input[type="number"] {
-  background: var(--panel-2);
-  color: var(--text);
-  border: 1px solid var(--line);
-  border-radius: 6px;
-  padding: 5px 7px;
+.opt:hover {
+  background: var(--cp-surface-soft);
+}
+
+.opt.on {
+  border-color: var(--cp-accent);
+  background: var(--cp-accent-soft);
+}
+
+.opt input {
+  margin-top: 3px;
+  accent-color: var(--cp-accent);
+}
+
+.opt .name {
+  color: var(--cp-text);
+  font-size: 13px;
+  font-weight: 650;
+  word-break: break-word;
+}
+
+.opt .meta {
+  color: var(--cp-text-muted);
+  font-size: 11px;
+}
+
+.opt .body {
+  flex: 1;
+  min-width: 0;
+}
+
+.opt.router .name {
+  color: var(--cp-accent);
+}
+
+select,
+input[type="number"] {
+  width: 100%;
+  padding: 7px 9px;
+  border: 1px solid var(--cp-border);
+  border-radius: 0.625rem;
+  background: var(--cp-surface);
+  color: var(--cp-text);
   font-family: inherit;
   font-size: 12px;
-  width: 100%;
+  outline: none;
 }
 
-.chips { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 6px; }
+select:focus,
+input[type="number"]:focus {
+  border-color: var(--cp-accent);
+  box-shadow: 0 0 0 2px var(--cp-highlight);
+}
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 7px;
+}
+
 .chip {
-  font-size: 10px; font-weight: 500; padding: 2px 7px; border-radius: 999px;
-  border: 1px solid var(--line); background: var(--bg); color: var(--muted);
+  padding: 3px 8px;
+  border: 1px solid var(--cp-border);
+  border-radius: 999px;
+  background: var(--cp-surface);
+  color: var(--cp-text-muted);
+  font-size: 10px;
+  font-weight: 550;
   cursor: pointer;
 }
-.chip:hover { border-color: var(--accent); }
-.chip.on { background: var(--accent); border-color: var(--accent); color: #06182c; font-weight: 600; }
 
-.field { margin-bottom: 10px; }
-.field label { display: block; color: var(--muted); font-size: 11px; margin-bottom: 3px; }
-.field .hint { color: var(--muted); font-size: 10px; margin-top: 3px; }
+.chip:hover {
+  border-color: var(--cp-accent);
+}
 
-.row { display: flex; gap: 10px; }
-.row > * { flex: 1; min-width: 0; }
+.chip.on {
+  border-color: var(--cp-accent);
+  background: var(--cp-accent);
+  color: var(--cp-accent-fg);
+  font-weight: 700;
+}
+
+.field {
+  margin-bottom: 11px;
+}
+
+.field label {
+  display: block;
+  margin-bottom: 4px;
+  color: var(--cp-text-muted);
+  font-size: 11px;
+  font-weight: 550;
+}
+
+.field .hint {
+  margin-top: 4px;
+  color: var(--cp-text-soft);
+  font-size: 10px;
+}
+
+.row {
+  display: flex;
+  gap: 10px;
+}
+
+.row > * {
+  flex: 1;
+  min-width: 0;
+}
 
 .check-inline {
-  display: flex; align-items: center; gap: 7px;
-  color: var(--muted); font-size: 12px; cursor: pointer;
-}
-.check-inline input { accent-color: var(--accent); }
-
-button {
-  font-family: inherit;
-  font-size: 13px;
-  font-weight: 600;
-  border-radius: 7px;
-  border: 1px solid var(--line);
-  background: var(--panel-2);
-  color: var(--text);
-  padding: 8px 14px;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--cp-text-muted);
+  font-size: 12px;
   cursor: pointer;
 }
-button:hover:not(:disabled) { border-color: var(--accent); }
-button:disabled { opacity: .45; cursor: not-allowed; }
-button.primary { background: var(--accent); border-color: var(--accent); color: #06182c; }
-button.danger { background: var(--bad); border-color: var(--bad); color: #2a0808; }
-button.ghost { font-weight: 500; font-size: 11px; padding: 3px 8px; }
 
-.actions { display: flex; gap: 8px; margin-top: 6px; }
-.actions button { flex: 1; }
+.check-inline input {
+  accent-color: var(--cp-accent);
+}
+
+button {
+  padding: 8px 14px;
+  border: 1px solid var(--cp-border);
+  border-radius: 0.625rem;
+  background: var(--cp-surface);
+  color: var(--cp-text);
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 650;
+  cursor: pointer;
+  transition: border-color 120ms ease, background-color 120ms ease;
+}
+
+button:hover:not(:disabled) {
+  border-color: var(--cp-accent);
+  background: var(--cp-accent-soft);
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+button.primary {
+  border-color: var(--cp-accent);
+  background: var(--cp-accent);
+  color: var(--cp-accent-fg);
+}
+
+button.primary:hover:not(:disabled) {
+  border-color: var(--cp-accent-hover);
+  background: var(--cp-accent-hover);
+}
+
+button.danger {
+  border-color: var(--cp-danger);
+  background: var(--cp-surface);
+  color: var(--cp-danger);
+}
+
+button.ghost {
+  padding: 4px 8px;
+  background: var(--cp-surface-soft);
+  font-size: 10px;
+  font-weight: 600;
+}
+
+.actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 7px;
+}
+
+.actions button {
+  flex: 1;
+}
 
 .estimate {
-  background: var(--panel-2);
-  border: 1px solid var(--line);
-  border-radius: 7px;
-  padding: 8px 10px;
+  margin-bottom: 11px;
+  padding: 9px 10px;
+  border: 1px solid var(--cp-border);
+  border-radius: 0.625rem;
+  background: var(--cp-surface-soft);
+  color: var(--cp-text-muted);
   font-size: 12px;
-  color: var(--muted);
-  margin-bottom: 10px;
 }
-.estimate b { color: var(--text); }
 
-.tabs { display: flex; gap: 6px; margin-bottom: 8px; }
+.estimate b {
+  color: var(--cp-text);
+}
+
+.estimate-error {
+  color: var(--cp-danger) !important;
+}
+
+.tabs {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 9px;
+}
+
 .tab {
-  font-size: 12px; padding: 4px 10px; border-radius: 6px;
-  border: 1px solid var(--line); background: var(--panel-2);
-  color: var(--muted); cursor: pointer;
+  padding: 5px 10px;
+  background: var(--cp-surface-soft);
+  color: var(--cp-text-muted);
+  font-size: 11px;
 }
-.tab.on { color: #06182c; background: var(--accent); border-color: var(--accent); font-weight: 600; }
 
-#progressWrap { margin-bottom: 12px; }
+.tab.on {
+  border-color: var(--cp-accent);
+  background: var(--cp-accent);
+  color: var(--cp-accent-fg);
+  font-weight: 700;
+}
+
+#progressWrap {
+  margin-bottom: 12px;
+}
+
 .bar {
-  height: 6px; background: var(--panel-2); border-radius: 999px; overflow: hidden;
-  border: 1px solid var(--line);
+  height: 7px;
+  overflow: hidden;
+  border: 1px solid var(--cp-border);
+  border-radius: 999px;
+  background: var(--cp-surface-soft);
 }
-.bar > i { display: block; height: 100%; background: var(--accent); width: 0; transition: width .2s; }
-.counters { display: flex; gap: 16px; margin-top: 8px; flex-wrap: wrap; font-size: 12px; color: var(--muted); }
-.counters b { color: var(--text); font-variant-numeric: tabular-nums; }
+
+.bar > i {
+  display: block;
+  width: 0;
+  height: 100%;
+  background: var(--cp-accent);
+  transition: width 200ms ease;
+}
+
+.counters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 18px;
+  margin-top: 9px;
+  color: var(--cp-text-muted);
+  font-size: 11px;
+}
+
+.counters b {
+  color: var(--cp-text);
+  font-variant-numeric: tabular-nums;
+}
+
 .counters.totals {
-  margin-top: 10px; padding-top: 9px; border-top: 1px solid var(--line);
+  margin-top: 11px;
+  padding-top: 10px;
+  border-top: 1px solid var(--cp-border);
 }
-.counters.totals b { color: var(--accent); }
-.counters.totals #tCost { color: var(--warn); }
+
+.counters.totals b {
+  color: var(--cp-accent);
+}
+
+.counters.totals #tCost {
+  color: var(--cp-warning);
+}
 
 .region-note {
-  margin-top: 8px; font-size: 11px; color: var(--muted);
-  display: flex; align-items: center; gap: 6px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 10px;
+  padding: 8px;
+  border-left: 3px solid var(--cp-success);
+  background: var(--cp-surface-soft);
+  color: var(--cp-text-muted);
+  font-size: 10px;
 }
+
 .pill {
-  display: inline-block; padding: 1px 6px; border-radius: 4px; font-size: 10px;
-  border: 1px solid var(--line); background: var(--panel-2); color: var(--muted);
+  display: inline-block;
   margin-left: 4px;
+  padding: 2px 6px;
+  border: 1px solid var(--cp-border);
+  border-radius: 4px;
+  background: var(--cp-surface-soft);
+  color: var(--cp-text-muted);
+  font-size: 9px;
 }
-.pill.scope { border-color: #5a4522; color: var(--warn); }
-.pill.study { border-color: #24557f; color: var(--accent); }
+
+.pill.scope {
+  border-color: var(--cp-warning);
+  color: var(--cp-warning);
+}
+
+.pill.study {
+  border-color: var(--cp-accent);
+  color: var(--cp-accent);
+}
 
 .charts {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(430px, 1fr));
-  gap: 14px;
+  gap: 16px;
 }
-.chart { background: var(--panel); border: 1px solid var(--line); border-radius: 10px; padding: 12px 14px 6px; }
-.chart h3 { margin: 0 0 2px; font-size: 13px; font-weight: 600; }
-.chart .why { margin: 0 0 8px; font-size: 11px; color: var(--muted); }
-.chart svg { display: block; width: 100%; height: auto; overflow: visible; }
 
-.legend { display: flex; gap: 12px; flex-wrap: wrap; font-size: 11px; color: var(--muted); padding: 4px 0 8px; }
-.legend i { display: inline-block; width: 9px; height: 9px; border-radius: 2px; margin-right: 5px; vertical-align: -1px; }
+.chart {
+  padding: 15px 16px 8px;
+}
 
-table { width: 100%; border-collapse: collapse; font-size: 12px; }
-th, td { padding: 6px 8px; text-align: right; border-bottom: 1px solid var(--line); white-space: nowrap; }
-th { color: var(--muted); font-weight: 600; font-size: 11px; text-transform: uppercase; letter-spacing: .04em; }
-td:first-child, th:first-child { text-align: left; }
-td { font-variant-numeric: tabular-nums; }
-tbody tr:hover { background: var(--panel-2); }
-.table-wrap { overflow-x: auto; }
+.chart h3 {
+  margin: 0 0 2px;
+  color: var(--cp-text);
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.chart .why {
+  margin: 0 0 9px;
+  color: var(--cp-text-muted);
+  font-size: 10px;
+}
+
+.chart svg {
+  display: block;
+  width: 100%;
+  height: auto;
+  overflow: visible;
+}
+
+.legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  padding: 5px 0 8px;
+  color: var(--cp-text-muted);
+  font-size: 10px;
+}
+
+.legend i {
+  display: inline-block;
+  width: 9px;
+  height: 9px;
+  margin-right: 5px;
+  border-radius: 2px;
+  vertical-align: -1px;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 11px;
+}
+
+th,
+td {
+  padding: 8px;
+  border-bottom: 1px solid var(--cp-border);
+  text-align: right;
+  white-space: nowrap;
+}
+
+th {
+  background: var(--cp-surface-soft);
+  color: var(--cp-text-muted);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+td:first-child,
+th:first-child {
+  text-align: left;
+}
+
+td {
+  font-variant-numeric: tabular-nums;
+}
+
+tbody tr:hover {
+  background: var(--cp-accent-soft);
+}
+
+.table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--cp-border);
+  border-radius: 0.625rem;
+}
 
 .log {
-  font-family: var(--mono);
-  font-size: 11px;
   max-height: 220px;
   overflow-y: auto;
-  background: #0b101a;
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  padding: 8px 10px;
+  padding: 9px 10px;
+  border: 1px solid var(--cp-border);
+  border-radius: 0.625rem;
+  background: var(--cp-surface-soft);
+  font-family: Consolas, "Courier New", Courier, monospace;
+  font-size: 10px;
 }
-.log div { white-space: pre; color: var(--muted); }
-.log .err { color: var(--bad); }
-.log .warm { color: #5c6d86; }
+
+.log div {
+  color: var(--cp-text-muted);
+  white-space: pre;
+}
+
+.log .err {
+  color: var(--cp-danger);
+}
+
+.log .warm {
+  color: var(--cp-text-soft);
+}
 
 .notice {
-  border-radius: 8px; padding: 10px 12px; font-size: 12px; margin-bottom: 12px;
-  border: 1px solid var(--line); background: var(--panel-2); color: var(--muted);
+  margin-bottom: 14px;
+  padding: 11px 13px;
+  border: 1px solid var(--cp-border);
+  border-left: 4px solid var(--cp-accent);
+  border-radius: 0.625rem;
+  background: var(--cp-surface);
+  color: var(--cp-text-muted);
+  font-size: 12px;
+  box-shadow: 0 1px 2px var(--cp-border);
 }
-.notice.error { border-color: #5a2222; background: #2a1212; color: #ffc9c9; }
-.notice.warn { border-color: #5a4522; background: #2a2112; color: #ffe2bb; }
-.notice b { color: var(--text); }
-.hidden { display: none !important; }
 
-.stack { display: flex; flex-direction: column; gap: 14px; }
-.muted { color: var(--muted); }
-.mono { font-family: var(--mono); }
-footer { padding: 8px 20px 24px; color: var(--muted); font-size: 11px; }
+.notice.error {
+  border-color: var(--cp-danger);
+  background: var(--cp-surface);
+  color: var(--cp-danger);
+}
+
+.notice.warn {
+  border-color: var(--cp-warning);
+  background: var(--cp-surface);
+  color: var(--cp-text);
+}
+
+.notice b {
+  color: var(--cp-text);
+}
+
+.hidden {
+  display: none !important;
+}
+
+.stack {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.muted {
+  color: var(--cp-text-muted);
+}
+
+.mono {
+  font-family: Consolas, "Courier New", Courier, monospace;
+}
+
+footer {
+  max-width: 1800px;
+  margin: 0 auto;
+  padding: 0 24px 28px;
+  color: var(--cp-text-muted);
+  font-size: 10px;
+}

--- a/Agents/AOAI-Model-Migration-Benchmark/qira-live-benchmark-console/tests/test_console.py
+++ b/Agents/AOAI-Model-Migration-Benchmark/qira-live-benchmark-console/tests/test_console.py
@@ -652,6 +652,16 @@ class HttpSurface(unittest.TestCase):
         self.assertEqual(status, 200)
         self.assertIn("Qira live model benchmark console", body)
 
+    def test_index_initializes_the_shared_light_theme(self):
+        status, body = self.get("/")
+        self.assertEqual(status, 200)
+        self.assertIn('get("clawpilotTheme")', body)
+        self.assertIn('setAttribute("data-theme", theme)', body)
+        status, css = self.get("/static/styles.css")
+        self.assertEqual(status, 200)
+        self.assertIn("--cp-bg: #f7f4ef", css)
+        self.assertIn('font-family: "Segoe UI", Aptos, Calibri', css)
+
     def test_catalog_reports_the_mode(self):
         status, body = self.get("/api/catalog")
         self.assertEqual(status, 200)


### PR DESCRIPTION
## Summary

- Replaces the dark Qira benchmark console with a warm, customer-facing light theme matching the supplied visual direction.
- Uses the shared Clawpilot light/dark theme variables throughout CSS and SVG charts; no hardcoded component colors remain.
- Adds a compact Microsoft Foundry brand header and improves cards, forms, tables, logs, notices, and selected states.
- Registers a canonical Qira card for the Linux Work VM Demo Portal, with the live app first in the grid and its Source link targeting `master`.
- The Demo Portal link pins `clawpilotTheme=light`, so customer entry always opens the requested light presentation.

## Validation

- JavaScript syntax check passed.
- Replay pack verified: 4 runs, 29 arm summaries.
- Portal test suite: 80 passed.
- Browser visual verification at 1680×1050: warm off-white page, white panels, deep rose accent.
- All four replay datasets rendered with 0 SVG overflow; summary rows 11 / 10 / 4 / 4.
- Demo Portal VM card moved to first position, service count remains 10, nginx validation passed.