### PR TITLE
Replace the portal Basic-Auth popup with an in-page sign-in

### DIFF
--- a/Agents/AOAI-Model-Migration-Benchmark/qira-live-benchmark-console/README-CN.md
+++ b/Agents/AOAI-Model-Migration-Benchmark/qira-live-benchmark-console/README-CN.md
@@ -142,10 +142,13 @@ Work VM 上端口明确错开：`8513` 是 Portal，`8514` 是反向隧道。Por
 ```
 
 网关校验的是 nginx 原来使用的同一批 htpasswd 文件，因此现有 Portal 密码继续有效：
-Apache `apr1` 哈希用纯 Python 校验，bcrypt 交给系统 `htpasswd` 程序。登录成功后
+Apache `apr1` 哈希用纯 Python 校验，bcrypt 交给系统 `htpasswd` 程序，并通过标准输入
+传递密码，绝不作为命令行参数（否则会经 `/proc` 泄露给本机其他账号）。登录成功后
 签发 HMAC-SHA256 会话 Cookie，带 `HttpOnly`、`SameSite=Lax` 并有有效期；一次登录
-即可覆盖 Portal 首页和所有反向代理的应用。`nginx-default.deployed.conf` 记录了
-Work VM 上当前实际运行的配置。
+即可覆盖 Portal 首页和所有反向代理的应用。跳转目标由 URL 字符白名单正则限制；登录
+失败统一等待到固定截止时间，避免泄露用户名是否存在。
+`nginx-default.deployed.conf` 记录了 Work VM 上当前实际运行的配置，被替换的旧配置
+保留在 VM 的 `/etc/nginx/backups/default.pre-portal-gate`。
 
 把三个 `deploy/*.env.example` 复制到 systemd 单元指定的路径。尤其是 `portal.env`
 必须在 `QIRA_ALLOWED_ORIGIN` 中明确列出实际使用的 HTTP 和/或 HTTPS 浏览器 Origin；

--- a/Agents/AOAI-Model-Migration-Benchmark/qira-live-benchmark-console/README-CN.md
+++ b/Agents/AOAI-Model-Migration-Benchmark/qira-live-benchmark-console/README-CN.md
@@ -130,6 +130,23 @@ Work VM 上端口明确错开：`8513` 是 Portal，`8514` 是反向隧道。Por
 `StateDirectory=qira-benchmark`，不需要写 `/opt`。变更接口只接受同源 JSON，Runner
 同时最多接受两个付费运行。
 
+### 页面内登录，取代浏览器弹窗
+
+`deploy/portal-gate/` 把 Demo Portal 的 Basic-Auth 弹窗换成与界面同风格的登录页。
+访问控制仍由 nginx 强制执行，只是改用 `auth_request` 询问本机 `127.0.0.1:8515`
+上的小服务：
+
+```text
+未登录请求 -> nginx auth_request -> 401 -> 302 跳转 /portal-login（登录页）
+已登录     -> nginx auth_request -> 204 -> 正常进入 Portal 或控制台
+```
+
+网关校验的是 nginx 原来使用的同一批 htpasswd 文件，因此现有 Portal 密码继续有效：
+Apache `apr1` 哈希用纯 Python 校验，bcrypt 交给系统 `htpasswd` 程序。登录成功后
+签发 HMAC-SHA256 会话 Cookie，带 `HttpOnly`、`SameSite=Lax` 并有有效期；一次登录
+即可覆盖 Portal 首页和所有反向代理的应用。`nginx-default.deployed.conf` 记录了
+Work VM 上当前实际运行的配置。
+
 把三个 `deploy/*.env.example` 复制到 systemd 单元指定的路径。尤其是 `portal.env`
 必须在 `QIRA_ALLOWED_ORIGIN` 中明确列出实际使用的 HTTP 和/或 HTTPS 浏览器 Origin；
 服务端绝不根据请求的 `Host` header 推导允许来源。
@@ -228,6 +245,7 @@ python server.py --port 8080
 | `bench_core.py` | 加载研究 harness；计划、执行、聚合 |
 | `static/` | 响应式暖色浅色界面并自动适配深色；零依赖 HTML/CSS/JS 与 SVG 图表 |
 | `deploy/demo-portal-card.html` | Linux Work VM Demo Portal 第一张卡片的标准注册片段 |
+| `deploy/portal-gate/` | 页面内登录网关：服务、systemd 单元与 nginx `auth_request` 配置 |
 | `scripts/build_replay_pack.py` | 重建 `replay/replay_pack.json`；`--check` 做校验 |
 | `replay/replay_pack.json` | 已记录的研究运行，用于无凭据演示 |
 | `history/` | 每次跑完的运行一个 JSON；已 git 忽略，首次运行时自动创建 |

--- a/Agents/AOAI-Model-Migration-Benchmark/qira-live-benchmark-console/README.md
+++ b/Agents/AOAI-Model-Migration-Benchmark/qira-live-benchmark-console/README.md
@@ -162,11 +162,16 @@ signed in         -> nginx auth_request -> 204 -> the portal or the console
 
 The gate verifies credentials against the same htpasswd files nginx used, so
 existing portal passwords keep working; Apache `apr1` hashes are checked in
-pure Python and bcrypt entries are delegated to the `htpasswd` binary. A
-successful sign-in issues an HMAC-SHA256 session cookie that is `HttpOnly`,
-`SameSite=Lax` and time limited, and one sign-in covers the portal home page
-and every proxied application. `nginx-default.deployed.conf` records the
-configuration currently running on the Work VM.
+pure Python and bcrypt entries are delegated to the `htpasswd` binary with the
+password supplied on stdin, never as a command-line argument that `/proc`
+would expose. A successful sign-in issues an HMAC-SHA256 session cookie that is
+`HttpOnly`, `SameSite=Lax` and time limited, and one sign-in covers the portal
+home page and every proxied application. Redirect targets are restricted by an
+anchored allowlist of URL characters, and failed sign-ins are held to a fixed
+deadline so they do not reveal whether a user name exists.
+`nginx-default.deployed.conf` records the configuration currently running on
+the Work VM; the configuration it replaced is kept on the VM at
+`/etc/nginx/backups/default.pre-portal-gate`.
 
 Copy the three `deploy/*.env.example` files to the paths named by the systemd
 units. In particular, `portal.env` must list the exact HTTP and/or HTTPS

--- a/Agents/AOAI-Model-Migration-Benchmark/qira-live-benchmark-console/README.md
+++ b/Agents/AOAI-Model-Migration-Benchmark/qira-live-benchmark-console/README.md
@@ -149,6 +149,25 @@ reverse-tunnel systemd units plus the nginx location. Both services use
 State-changing endpoints require JSON from the same origin, and the runner
 accepts at most two active paid runs at once.
 
+### In-page sign-in instead of the browser popup
+
+`deploy/portal-gate/` turns the Demo Portal's Basic-Auth dialog into a themed
+sign-in page. nginx still enforces access, but through `auth_request` against a
+small local service on `127.0.0.1:8515`:
+
+```text
+anonymous request -> nginx auth_request -> 401 -> 302 /portal-login (themed form)
+signed in         -> nginx auth_request -> 204 -> the portal or the console
+```
+
+The gate verifies credentials against the same htpasswd files nginx used, so
+existing portal passwords keep working; Apache `apr1` hashes are checked in
+pure Python and bcrypt entries are delegated to the `htpasswd` binary. A
+successful sign-in issues an HMAC-SHA256 session cookie that is `HttpOnly`,
+`SameSite=Lax` and time limited, and one sign-in covers the portal home page
+and every proxied application. `nginx-default.deployed.conf` records the
+configuration currently running on the Work VM.
+
 Copy the three `deploy/*.env.example` files to the paths named by the systemd
 units. In particular, `portal.env` must list the exact HTTP and/or HTTPS
 browser origins in `QIRA_ALLOWED_ORIGIN`; the server never trusts the request's
@@ -272,6 +291,7 @@ comparable too.
 | `bench_core.py` | Loads the study harness; planning, execution, aggregation |
 | `static/` | Responsive warm-light UI with dark-mode adaptation; dependency-free HTML/CSS/JS and SVG charts |
 | `deploy/demo-portal-card.html` | Canonical first-card registration for the Linux Work VM Demo Portal |
+| `deploy/portal-gate/` | In-page sign-in gate: service, systemd unit, and nginx `auth_request` wiring |
 | `scripts/build_replay_pack.py` | Rebuilds `replay/replay_pack.json`; `--check` verifies it |
 | `replay/replay_pack.json` | Recorded study runs for credential-free demonstration |
 | `history/` | One JSON per completed run; git-ignored, created on first run |

--- a/Agents/AOAI-Model-Migration-Benchmark/qira-live-benchmark-console/deploy/portal-gate/gate.py
+++ b/Agents/AOAI-Model-Migration-Benchmark/qira-live-benchmark-console/deploy/portal-gate/gate.py
@@ -61,8 +61,10 @@ MAX_BODY_BYTES = 16 * 1024
 
 # Only the characters a URL path and query may legitimately contain. An
 # allowlist is used rather than stripping bad characters, so a redirect target
-# can never carry a control character into a response header.
-SAFE_NEXT_PATTERN = re.compile(r"^/[A-Za-z0-9._~!$&'()*+,;=:@%/?-]*$")
+# can never carry a control character into a response header. The pattern is
+# anchored with \A and \Z rather than ^ and $, because in Python `$` also
+# matches just before a trailing newline and would let "/path\n" through.
+SAFE_NEXT_PATTERN = re.compile(r"\A/[A-Za-z0-9._~!$&'()*+,;=:@%/?-]*\Z")
 
 # A failed sign-in must not be cheap to retry, and it must not reveal whether
 # the user name exists. This is a deadline rather than an added pause: every

--- a/Agents/AOAI-Model-Migration-Benchmark/qira-live-benchmark-console/deploy/portal-gate/gate.py
+++ b/Agents/AOAI-Model-Migration-Benchmark/qira-live-benchmark-console/deploy/portal-gate/gate.py
@@ -31,6 +31,7 @@ import hashlib
 import hmac
 import html
 import os
+import re
 import secrets
 import shutil
 import subprocess
@@ -58,9 +59,16 @@ PORTAL_SUBTITLE = os.environ.get(
 )
 MAX_BODY_BYTES = 16 * 1024
 
-# A wrong password must not be cheap to guess in bulk, and it must not reveal
-# whether the user name exists. Every failure takes the same visible time.
-FAILURE_DELAY_SECONDS = 0.4
+# Only the characters a URL path and query may legitimately contain. An
+# allowlist is used rather than stripping bad characters, so a redirect target
+# can never carry a control character into a response header.
+SAFE_NEXT_PATTERN = re.compile(r"^/[A-Za-z0-9._~!$&'()*+,;=:@%/?-]*$")
+
+# A failed sign-in must not be cheap to retry, and it must not reveal whether
+# the user name exists. This is a deadline rather than an added pause: every
+# rejection returns after the same elapsed time regardless of which check
+# failed or how expensive the hash comparison was.
+FAILURE_DEADLINE_SECONDS = float(os.environ.get("PORTAL_GATE_FAILURE_DEADLINE", "0.5"))
 
 
 # --------------------------------------------------------------------------
@@ -171,13 +179,21 @@ def apr1_hash(password: bytes, salt: bytes) -> str:
 
 
 def _verify_with_htpasswd(path: Path, user: str, password: str) -> bool:
-    """Delegate bcrypt/SHA entries to the htpasswd binary already on the VM."""
+    """
+    Delegate bcrypt/SHA entries to the htpasswd binary already on the VM.
+
+    The password is written to stdin rather than passed as an argument: argv is
+    world-readable through /proc/<pid>/cmdline and is recorded by process
+    accounting, so `-b` would expose every signed-in user's password to any
+    local account. Apache's own documentation warns about exactly this.
+    """
     binary = shutil.which("htpasswd")
     if not binary:
         return False
     try:
         result = subprocess.run(
-            [binary, "-vb", str(path), user, password],
+            [binary, "-vi", str(path), user],
+            input=password.encode("utf-8"),
             capture_output=True,
             timeout=10,
             check=False,
@@ -225,13 +241,13 @@ def safe_next(raw: str | None) -> str:
     The value reaches us through parse_qs, which decodes percent escapes, so a
     caller can smuggle real control characters (``%0d%0a``) into it. Those must
     never reach a response header or they would split it, letting an attacker
-    append headers of their own to the redirect.
+    append headers of their own to the redirect. Rather than removing bad
+    characters, this accepts only the characters a URL path and query may
+    contain, so anything unexpected falls back to the portal home page.
     """
-    if not raw:
+    if not raw or not SAFE_NEXT_PATTERN.match(raw):
         return "/"
-    if any(ord(ch) < 0x20 or ord(ch) == 0x7F for ch in raw):
-        return "/"
-    if not raw.startswith("/") or raw.startswith("//") or raw.startswith("/\\"):
+    if raw.startswith("//") or raw.startswith("/\\"):
         return "/"
     if raw.startswith("/portal-login") or raw.startswith("/portal-logout"):
         return "/"
@@ -496,6 +512,7 @@ class Handler(BaseHTTPRequestHandler):
         if length > MAX_BODY_BYTES:
             self._send(413, b"Too large", "text/plain; charset=utf-8")
             return
+        started = time.monotonic()
         raw = self.rfile.read(length).decode("utf-8", errors="replace") if length else ""
         form = parse_qs(raw, keep_blank_values=True)
         target = safe_next(form.get("next", [None])[0])
@@ -512,7 +529,11 @@ class Handler(BaseHTTPRequestHandler):
             )
             return
 
-        time.sleep(FAILURE_DELAY_SECONDS)
+        # Hold every rejection to the same deadline, so an unknown user and a
+        # wrong password for a known user are indistinguishable by timing.
+        remaining = FAILURE_DEADLINE_SECONDS - (time.monotonic() - started)
+        if remaining > 0:
+            time.sleep(remaining)
         self._send_page(
             401, login_page(target, "That user name and password did not match.")
         )

--- a/Agents/AOAI-Model-Migration-Benchmark/qira-live-benchmark-console/deploy/portal-gate/gate.py
+++ b/Agents/AOAI-Model-Migration-Benchmark/qira-live-benchmark-console/deploy/portal-gate/gate.py
@@ -74,8 +74,13 @@ def load_secret() -> bytes:
             return value
     secret = base64.urlsafe_b64encode(secrets.token_bytes(48))
     SECRET_PATH.parent.mkdir(parents=True, exist_ok=True)
-    SECRET_PATH.write_bytes(secret + b"\n")
-    SECRET_PATH.chmod(0o600)
+    # Create the file already private. Writing first and calling chmod after
+    # would leave the signing key world-readable for that window.
+    handle = os.open(SECRET_PATH, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        os.write(handle, secret + b"\n")
+    finally:
+        os.close(handle)
     return secret
 
 
@@ -214,8 +219,17 @@ def check_credentials(user: str, password: str) -> bool:
 # --------------------------------------------------------------------------
 
 def safe_next(raw: str | None) -> str:
-    """Only allow same-site paths, so the form cannot become an open redirect."""
+    """
+    Only allow same-site paths, so the form cannot become an open redirect.
+
+    The value reaches us through parse_qs, which decodes percent escapes, so a
+    caller can smuggle real control characters (``%0d%0a``) into it. Those must
+    never reach a response header or they would split it, letting an attacker
+    append headers of their own to the redirect.
+    """
     if not raw:
+        return "/"
+    if any(ord(ch) < 0x20 or ord(ch) == 0x7F for ch in raw):
         return "/"
     if not raw.startswith("/") or raw.startswith("//") or raw.startswith("/\\"):
         return "/"
@@ -416,6 +430,10 @@ class Handler(BaseHTTPRequestHandler):
         self.send_header("Content-Length", str(len(body)))
         self.send_header("Cache-Control", "no-store")
         for key, value in headers or []:
+            # Defence in depth: a header value that still carried a control
+            # character would split the response, so refuse to emit one.
+            if any(ord(ch) < 0x20 or ord(ch) == 0x7F for ch in value):
+                raise ValueError(f"refusing to send a control character in header {key}")
             self.send_header(key, value)
         self.end_headers()
         if body:

--- a/Agents/AOAI-Model-Migration-Benchmark/qira-live-benchmark-console/deploy/portal-gate/gate.py
+++ b/Agents/AOAI-Model-Migration-Benchmark/qira-live-benchmark-console/deploy/portal-gate/gate.py
@@ -430,11 +430,16 @@ class Handler(BaseHTTPRequestHandler):
         self.send_header("Content-Length", str(len(body)))
         self.send_header("Cache-Control", "no-store")
         for key, value in headers or []:
-            # Defence in depth: a header value that still carried a control
-            # character would split the response, so refuse to emit one.
-            if any(ord(ch) < 0x20 or ord(ch) == 0x7F for ch in value):
+            # Defence in depth. A control character left in a header value would
+            # split the response, so build the emitted value by filtering rather
+            # than by trusting the caller, and refuse the request if anything had
+            # to be removed.
+            filtered = "".join(
+                ch for ch in value if 0x20 <= ord(ch) != 0x7F
+            )
+            if filtered != value:
                 raise ValueError(f"refusing to send a control character in header {key}")
-            self.send_header(key, value)
+            self.send_header(key, filtered)
         self.end_headers()
         if body:
             self.wfile.write(body)

--- a/Agents/AOAI-Model-Migration-Benchmark/qira-live-benchmark-console/deploy/portal-gate/gate.py
+++ b/Agents/AOAI-Model-Migration-Benchmark/qira-live-benchmark-console/deploy/portal-gate/gate.py
@@ -1,0 +1,522 @@
+"""
+In-page login gate for the Linux Work VM Demo Portal.
+
+Replaces the browser's Basic-Auth popup with a themed sign-in page. nginx keeps
+enforcing access with `auth_request`; this service only answers three questions:
+
+    GET  /portal-auth    is this request already signed in?   (nginx subrequest)
+    GET  /portal-login   render the sign-in page
+    POST /portal-login   check credentials, issue a session cookie
+    GET  /portal-logout  drop the session
+
+Credentials are verified against the htpasswd files nginx already used, so the
+existing portal password keeps working and nobody is locked out by the switch.
+Apache's apr1 (MD5) hashes are verified in pure Python; bcrypt and SHA entries
+are delegated to the system `htpasswd` binary, which is already installed.
+
+The session cookie is an HMAC-SHA256 token over the user name and expiry, keyed
+by a secret generated on first start. It is HttpOnly and SameSite=Lax, so it is
+never sent on a cross-site POST - the same property the console's own Origin
+check relies on.
+
+Usage:
+    python gate.py --port 8515 [--host 127.0.0.1]
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import hmac
+import html
+import os
+import secrets
+import shutil
+import subprocess
+import time
+from http.cookies import SimpleCookie
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+ROOT = Path(__file__).resolve().parent
+COOKIE_NAME = "portal_session"
+SESSION_TTL_SECONDS = int(os.environ.get("PORTAL_GATE_TTL", str(12 * 3600)))
+SECRET_PATH = Path(os.environ.get("PORTAL_GATE_SECRET", "/etc/qira-benchmark/portal-gate.secret"))
+USER_FILES = [
+    Path(p.strip())
+    for p in os.environ.get(
+        "PORTAL_GATE_USER_FILES",
+        "/etc/nginx/.htpasswd,/etc/nginx/.htpasswd-qira",
+    ).split(",")
+    if p.strip()
+]
+PORTAL_TITLE = os.environ.get("PORTAL_GATE_TITLE", "AI Services Hub")
+PORTAL_SUBTITLE = os.environ.get(
+    "PORTAL_GATE_SUBTITLE", "Microsoft Foundry demo portal - Linux Work VM"
+)
+MAX_BODY_BYTES = 16 * 1024
+
+# A wrong password must not be cheap to guess in bulk, and it must not reveal
+# whether the user name exists. Every failure takes the same visible time.
+FAILURE_DELAY_SECONDS = 0.4
+
+
+# --------------------------------------------------------------------------
+# Secret and session tokens
+# --------------------------------------------------------------------------
+
+def load_secret() -> bytes:
+    if SECRET_PATH.is_file():
+        value = SECRET_PATH.read_bytes().strip()
+        if value:
+            return value
+    secret = base64.urlsafe_b64encode(secrets.token_bytes(48))
+    SECRET_PATH.parent.mkdir(parents=True, exist_ok=True)
+    SECRET_PATH.write_bytes(secret + b"\n")
+    SECRET_PATH.chmod(0o600)
+    return secret
+
+
+SECRET = load_secret()
+
+
+def issue_token(user: str, ttl: int = SESSION_TTL_SECONDS) -> str:
+    expires = int(time.time()) + ttl
+    payload = f"{user}|{expires}".encode("utf-8")
+    body = base64.urlsafe_b64encode(payload).decode("ascii").rstrip("=")
+    signature = hmac.new(SECRET, body.encode("ascii"), hashlib.sha256).digest()
+    return body + "." + base64.urlsafe_b64encode(signature).decode("ascii").rstrip("=")
+
+
+def verify_token(token: str) -> str | None:
+    """Return the signed-in user name, or None when the token is not usable."""
+    if not token or "." not in token:
+        return None
+    body, _, signature = token.partition(".")
+    expected = hmac.new(SECRET, body.encode("ascii"), hashlib.sha256).digest()
+    try:
+        supplied = base64.urlsafe_b64decode(signature + "=" * (-len(signature) % 4))
+    except (ValueError, TypeError):
+        return None
+    if not hmac.compare_digest(expected, supplied):
+        return None
+    try:
+        payload = base64.urlsafe_b64decode(body + "=" * (-len(body) % 4)).decode("utf-8")
+        user, _, expires = payload.rpartition("|")
+        if not user or time.time() > int(expires):
+            return None
+    except (ValueError, TypeError, UnicodeDecodeError):
+        return None
+    return user
+
+
+# --------------------------------------------------------------------------
+# Credential verification
+# --------------------------------------------------------------------------
+
+APR1_ALPHABET = "./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+
+
+def _apr1_encode(final: bytes) -> str:
+    """Apache's custom base64 ordering for the apr1 digest."""
+    order = ((0, 6, 12), (1, 7, 13), (2, 8, 14), (3, 9, 15), (4, 10, 5))
+    out = []
+    for a, b, c in order:
+        value = (final[a] << 16) | (final[b] << 8) | final[c]
+        for _ in range(4):
+            out.append(APR1_ALPHABET[value & 0x3F])
+            value >>= 6
+    value = final[11]
+    for _ in range(2):
+        out.append(APR1_ALPHABET[value & 0x3F])
+        value >>= 6
+    return "".join(out)
+
+
+def apr1_hash(password: bytes, salt: bytes) -> str:
+    """Apache MD5 (``$apr1$``) crypt, the htpasswd default format."""
+    magic = b"$apr1$"
+    ctx = hashlib.md5(password + magic + salt)
+    alternate = hashlib.md5(password + salt + password).digest()
+
+    remaining = len(password)
+    while remaining > 0:
+        ctx.update(alternate[: min(remaining, 16)])
+        remaining -= 16
+
+    remaining = len(password)
+    while remaining:
+        ctx.update(b"\0" if remaining & 1 else password[:1])
+        remaining >>= 1
+
+    final = ctx.digest()
+    for i in range(1000):
+        step = hashlib.md5()
+        step.update(password if i & 1 else final)
+        if i % 3:
+            step.update(salt)
+        if i % 7:
+            step.update(password)
+        step.update(final if i & 1 else password)
+        final = step.digest()
+
+    return magic.decode() + salt.decode() + "$" + _apr1_encode(final)
+
+
+def _verify_with_htpasswd(path: Path, user: str, password: str) -> bool:
+    """Delegate bcrypt/SHA entries to the htpasswd binary already on the VM."""
+    binary = shutil.which("htpasswd")
+    if not binary:
+        return False
+    try:
+        result = subprocess.run(
+            [binary, "-vb", str(path), user, password],
+            capture_output=True,
+            timeout=10,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return result.returncode == 0
+
+
+def check_credentials(user: str, password: str) -> bool:
+    if not user or not password or "\n" in user or ":" in user:
+        return False
+    for path in USER_FILES:
+        if not path.is_file():
+            continue
+        try:
+            lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+        except OSError:
+            continue
+        for line in lines:
+            name, _, stored = line.partition(":")
+            if name != user or not stored:
+                continue
+            if stored.startswith("$apr1$"):
+                parts = stored.split("$")
+                if len(parts) < 4:
+                    continue
+                if hmac.compare_digest(
+                    apr1_hash(password.encode("utf-8"), parts[2].encode("ascii")), stored
+                ):
+                    return True
+            elif _verify_with_htpasswd(path, user, password):
+                return True
+    return False
+
+
+# --------------------------------------------------------------------------
+# Sign-in page
+# --------------------------------------------------------------------------
+
+def safe_next(raw: str | None) -> str:
+    """Only allow same-site paths, so the form cannot become an open redirect."""
+    if not raw:
+        return "/"
+    if not raw.startswith("/") or raw.startswith("//") or raw.startswith("/\\"):
+        return "/"
+    if raw.startswith("/portal-login") or raw.startswith("/portal-logout"):
+        return "/"
+    return raw
+
+
+def login_page(next_url: str, error: str | None = None) -> str:
+    message = (
+        f'<p class="form-error" role="alert">{html.escape(error)}</p>' if error else ""
+    )
+    hours = SESSION_TTL_SECONDS // 3600
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Sign in - {html.escape(PORTAL_TITLE)}</title>
+<script>
+  (() => {{
+    const param = new URLSearchParams(window.location.search).get("clawpilotTheme");
+    const theme =
+      param || (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
+    document.documentElement.setAttribute("data-theme", theme);
+  }})();
+</script>
+<style>
+:root {{
+  color-scheme: light;
+  --cp-bg: #f7f4ef;
+  --cp-surface: #ffffff;
+  --cp-border: #dedede;
+  --cp-text: #242424;
+  --cp-text-muted: #5c5c5c;
+  --cp-accent: #b11f4b;
+  --cp-accent-hover: #9a1a41;
+  --cp-accent-fg: #ffffff;
+  --cp-danger: #dc2626;
+  --cp-highlight: rgba(177, 31, 75, 0.12);
+}}
+html[data-theme="dark"] {{
+  color-scheme: dark;
+  --cp-bg: #3d3b3a;
+  --cp-surface: #292929;
+  --cp-border: #474747;
+  --cp-text: #dedede;
+  --cp-text-muted: #919191;
+  --cp-accent: #fd8ea1;
+  --cp-accent-hover: #fb7b91;
+  --cp-accent-fg: #1a1a1a;
+  --cp-danger: #f87171;
+  --cp-highlight: rgba(253, 142, 161, 0.12);
+}}
+* {{ box-sizing: border-box; }}
+body {{
+  display: grid;
+  place-items: center;
+  min-height: 100vh;
+  margin: 0;
+  padding: 24px;
+  background: var(--cp-bg);
+  color: var(--cp-text);
+  font-family: "Segoe UI", Aptos, Calibri, -apple-system, BlinkMacSystemFont, sans-serif;
+}}
+.card {{
+  width: 100%;
+  max-width: 400px;
+  padding: 32px;
+  border: 1px solid var(--cp-border);
+  border-radius: 16px;
+  background: var(--cp-surface);
+  box-shadow: 0 0 2px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.14);
+}}
+.brand {{ display: flex; align-items: center; gap: 12px; margin-bottom: 22px; }}
+.brand-mark {{
+  display: grid;
+  width: 42px;
+  height: 42px;
+  place-items: center;
+  border-radius: 0.625rem;
+  background: var(--cp-accent);
+  color: var(--cp-accent-fg);
+  font-size: 19px;
+  font-weight: 750;
+}}
+h1 {{ margin: 0; font-size: 18px; font-weight: 650; letter-spacing: -0.015em; }}
+.sub {{ margin-top: 2px; color: var(--cp-text-muted); font-size: 11px; }}
+label {{
+  display: block;
+  margin-bottom: 5px;
+  color: var(--cp-text-muted);
+  font-size: 11px;
+  font-weight: 600;
+}}
+input {{
+  width: 100%;
+  margin-bottom: 15px;
+  padding: 10px 12px;
+  border: 1px solid var(--cp-border);
+  border-radius: 0.625rem;
+  background: var(--cp-surface);
+  color: var(--cp-text);
+  font-family: inherit;
+  font-size: 14px;
+  outline: none;
+}}
+input:focus {{ border-color: var(--cp-accent); box-shadow: 0 0 0 2px var(--cp-highlight); }}
+button {{
+  width: 100%;
+  padding: 11px;
+  border: 1px solid var(--cp-accent);
+  border-radius: 0.625rem;
+  background: var(--cp-accent);
+  color: var(--cp-accent-fg);
+  font-family: inherit;
+  font-size: 14px;
+  font-weight: 650;
+  cursor: pointer;
+}}
+button:hover {{ border-color: var(--cp-accent-hover); background: var(--cp-accent-hover); }}
+.form-error {{
+  margin: 0 0 15px;
+  padding: 9px 11px;
+  border: 1px solid var(--cp-danger);
+  border-left-width: 4px;
+  border-radius: 0.625rem;
+  background: var(--cp-surface);
+  color: var(--cp-danger);
+  font-size: 12px;
+}}
+.foot {{
+  margin: 18px 0 0;
+  padding-top: 14px;
+  border-top: 1px solid var(--cp-border);
+  color: var(--cp-text-muted);
+  font-size: 10px;
+  line-height: 1.6;
+}}
+</style>
+</head>
+<body>
+  <main class="card">
+    <div class="brand">
+      <div class="brand-mark" aria-hidden="true">AI</div>
+      <div>
+        <h1>{html.escape(PORTAL_TITLE)}</h1>
+        <div class="sub">{html.escape(PORTAL_SUBTITLE)}</div>
+      </div>
+    </div>
+    {message}
+    <form method="post" action="/portal-login">
+      <input type="hidden" name="next" value="{html.escape(next_url, quote=True)}">
+      <label for="username">Username</label>
+      <input id="username" name="username" autocomplete="username" autofocus required>
+      <label for="password">Password</label>
+      <input id="password" name="password" type="password" autocomplete="current-password" required>
+      <button type="submit">Sign in</button>
+    </form>
+    <p class="foot">Demo environment. This browser stays signed in for {hours} hours.</p>
+  </main>
+</body>
+</html>
+"""
+
+
+# --------------------------------------------------------------------------
+# HTTP
+# --------------------------------------------------------------------------
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+    server_version = "PortalGate/1.0"
+
+    def log_message(self, fmt, *args):  # noqa: A003 - only log real sign-in traffic
+        if self.path.startswith("/portal-auth"):
+            return
+        super().log_message(fmt, *args)
+
+    # -- helpers ---------------------------------------------------------
+    def _session_user(self) -> str | None:
+        raw = self.headers.get("Cookie")
+        if not raw:
+            return None
+        jar = SimpleCookie()
+        try:
+            jar.load(raw)
+        except Exception:  # noqa: BLE001 - a malformed cookie is simply not a session
+            return None
+        morsel = jar.get(COOKIE_NAME)
+        return verify_token(morsel.value) if morsel else None
+
+    def _send(self, status: int, body: bytes = b"", content_type: str | None = None,
+              headers: list[tuple[str, str]] | None = None) -> None:
+        self.send_response(status)
+        if content_type:
+            self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Cache-Control", "no-store")
+        for key, value in headers or []:
+            self.send_header(key, value)
+        self.end_headers()
+        if body:
+            self.wfile.write(body)
+
+    def _send_page(self, status: int, markup: str,
+                   headers: list[tuple[str, str]] | None = None) -> None:
+        self._send(status, markup.encode("utf-8"), "text/html; charset=utf-8", headers)
+
+    def _cookie_header(self, value: str, max_age: int) -> tuple[str, str]:
+        parts = [
+            f"{COOKIE_NAME}={value}",
+            "Path=/",
+            "HttpOnly",
+            "SameSite=Lax",
+            f"Max-Age={max_age}",
+        ]
+        if self.headers.get("X-Forwarded-Proto", "").split(",")[0].strip() == "https":
+            parts.append("Secure")
+        return ("Set-Cookie", "; ".join(parts))
+
+    # -- routes ----------------------------------------------------------
+    def do_GET(self):  # noqa: N802 - BaseHTTPRequestHandler API
+        parsed = urlparse(self.path)
+        route = parsed.path
+        query = parse_qs(parsed.query)
+
+        if route == "/portal-auth":
+            self._send(204 if self._session_user() else 401)
+            return
+
+        if route == "/portal-login":
+            target = safe_next(query.get("next", [None])[0])
+            if self._session_user():
+                self._send(302, headers=[("Location", target)])
+                return
+            self._send_page(200, login_page(target))
+            return
+
+        if route == "/portal-logout":
+            self._send(
+                302,
+                headers=[("Location", "/portal-login"), self._cookie_header("", 0)],
+            )
+            return
+
+        self._send(404, b"Not found", "text/plain; charset=utf-8")
+
+    def do_POST(self):  # noqa: N802 - BaseHTTPRequestHandler API
+        if urlparse(self.path).path != "/portal-login":
+            self._send(404, b"Not found", "text/plain; charset=utf-8")
+            return
+
+        length = int(self.headers.get("Content-Length") or 0)
+        if length > MAX_BODY_BYTES:
+            self._send(413, b"Too large", "text/plain; charset=utf-8")
+            return
+        raw = self.rfile.read(length).decode("utf-8", errors="replace") if length else ""
+        form = parse_qs(raw, keep_blank_values=True)
+        target = safe_next(form.get("next", [None])[0])
+        user = (form.get("username", [""])[0] or "").strip()
+        password = form.get("password", [""])[0] or ""
+
+        if check_credentials(user, password):
+            self._send(
+                303,
+                headers=[
+                    ("Location", target),
+                    self._cookie_header(issue_token(user), SESSION_TTL_SECONDS),
+                ],
+            )
+            return
+
+        time.sleep(FAILURE_DELAY_SECONDS)
+        self._send_page(
+            401, login_page(target, "That user name and password did not match.")
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8515)
+    args = parser.parse_args()
+
+    present = [str(p) for p in USER_FILES if p.is_file()]
+    print(f"Portal sign-in gate on {args.host}:{args.port}")
+    print(f"  credential sources: {', '.join(present) if present else 'NONE FOUND'}")
+    if not present:
+        print("  [warn] no htpasswd file is readable; every sign-in will fail")
+
+    server = ThreadingHTTPServer((args.host, args.port), Handler)
+    server.daemon_threads = True
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nstopping")
+    finally:
+        server.server_close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Agents/AOAI-Model-Migration-Benchmark/qira-live-benchmark-console/deploy/portal-gate/nginx-default.deployed.conf
+++ b/Agents/AOAI-Model-Migration-Benchmark/qira-live-benchmark-console/deploy/portal-gate/nginx-default.deployed.conf
@@ -1,0 +1,72 @@
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+    server_name _;
+    include snippets/acme.conf;
+
+    root /var/www/html;
+    index index.html;
+
+
+    # --- in-page sign-in gate (replaces the Basic-Auth popup) ---
+    location = /portal-auth {
+        internal;
+        proxy_pass              http://127.0.0.1:8515/portal-auth;
+        proxy_pass_request_body off;
+        proxy_set_header        Content-Length "";
+        proxy_set_header        X-Original-URI $request_uri;
+        proxy_set_header        X-Forwarded-Proto $scheme;
+    }
+
+    location = /portal-login {
+        proxy_pass       http://127.0.0.1:8515/portal-login;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location = /portal-logout {
+        proxy_pass       http://127.0.0.1:8515/portal-logout;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location @portal_signin {
+        return 302 /portal-login?next=$request_uri;
+    }
+
+    location /mxc-routing/ {
+        auth_request /portal-auth;
+        error_page 401 = @portal_signin;
+        proxy_pass http://127.0.0.1:8512/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto http;
+        proxy_read_timeout 240s;
+        client_max_body_size 20M;
+    }
+
+    location /qira-benchmark/ {
+        auth_request /portal-auth;
+        error_page 401 = @portal_signin;
+        proxy_pass http://127.0.0.1:8513/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 3700s;
+        client_max_body_size 2M;
+    }
+
+    location / {
+        auth_request /portal-auth;
+        error_page 401 = @portal_signin;
+        try_files $uri $uri/ =404;
+    }
+}

--- a/Agents/AOAI-Model-Migration-Benchmark/qira-live-benchmark-console/deploy/portal-gate/nginx-portal-gate.conf
+++ b/Agents/AOAI-Model-Migration-Benchmark/qira-live-benchmark-console/deploy/portal-gate/nginx-portal-gate.conf
@@ -1,0 +1,59 @@
+# Demo Portal sign-in gate: replaces the browser Basic-Auth popup with a themed
+# in-page login. Merge these blocks into the default server on the portal VM.
+#
+# Every protected location keeps its access control; the difference is that an
+# unauthenticated request is redirected to a real page instead of triggering the
+# browser's native credential dialog.
+
+# nginx asks the gate whether the caller already has a valid session cookie.
+location = /portal-auth {
+    internal;
+    proxy_pass              http://127.0.0.1:8515/portal-auth;
+    proxy_pass_request_body off;
+    proxy_set_header        Content-Length "";
+    proxy_set_header        X-Original-URI $request_uri;
+    proxy_set_header        X-Forwarded-Proto $scheme;
+}
+
+# The sign-in page itself must stay reachable without a session.
+location = /portal-login {
+    proxy_pass       http://127.0.0.1:8515/portal-login;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+}
+
+location = /portal-logout {
+    proxy_pass       http://127.0.0.1:8515/portal-logout;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-Proto $scheme;
+}
+
+# Send an unauthenticated caller to the form, remembering where they were going.
+location @portal_signin {
+    return 302 /portal-login?next=$request_uri;
+}
+
+# --- protected locations -----------------------------------------------------
+# Replace `auth_basic` + `auth_basic_user_file` in each protected location with:
+#
+#     auth_request /portal-auth;
+#     error_page 401 = @portal_signin;
+#
+# For example, the Qira console:
+#
+# location /qira-benchmark/ {
+#     auth_request /portal-auth;
+#     error_page 401 = @portal_signin;
+#     proxy_pass http://127.0.0.1:8513/;
+#     proxy_http_version 1.1;
+#     proxy_set_header Host $host;
+#     proxy_set_header X-Real-IP $remote_addr;
+#     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+#     proxy_set_header X-Forwarded-Proto $scheme;
+#     proxy_buffering off;
+#     proxy_cache off;
+#     proxy_read_timeout 3700s;
+#     client_max_body_size 2M;
+# }

--- a/Agents/AOAI-Model-Migration-Benchmark/qira-live-benchmark-console/deploy/portal-gate/portal-gate.service
+++ b/Agents/AOAI-Model-Migration-Benchmark/qira-live-benchmark-console/deploy/portal-gate/portal-gate.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Demo Portal in-page sign-in gate
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/opt/portal-gate
+Environment=PYTHONDONTWRITEBYTECODE=1
+EnvironmentFile=-/etc/qira-benchmark/portal-gate.env
+ExecStart=/usr/bin/python3 gate.py --host 127.0.0.1 --port 8515
+Restart=on-failure
+RestartSec=5
+NoNewPrivileges=true
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target

--- a/Agents/AOAI-Model-Migration-Benchmark/qira-live-benchmark-console/tests/test_portal_gate.py
+++ b/Agents/AOAI-Model-Migration-Benchmark/qira-live-benchmark-console/tests/test_portal_gate.py
@@ -1,0 +1,216 @@
+"""Offline tests for the Demo Portal sign-in gate: no network, no real users."""
+
+import http.client
+import importlib.util
+import os
+import subprocess
+import tempfile
+import threading
+import unittest
+from http.server import ThreadingHTTPServer
+from pathlib import Path
+from unittest.mock import patch
+
+GATE_PATH = Path(__file__).resolve().parents[1] / "deploy" / "portal-gate" / "gate.py"
+_SECRET_DIR = tempfile.TemporaryDirectory()
+os.environ.setdefault("PORTAL_GATE_SECRET", str(Path(_SECRET_DIR.name) / "secret"))
+
+SPEC = importlib.util.spec_from_file_location("portal_gate", GATE_PATH)
+GATE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(GATE)
+
+# Generated externally by Apache's own tool, so this fixture is an independent
+# reference rather than output of the implementation under test:
+#     htpasswd -nbm demo correct-horse
+APR1_LINE = "demo:$apr1$koog43vM$cQiCIAlM6zzTKRl5GLBZl1"
+
+
+class Apr1Verification(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.path = Path(self.tmp.name) / ".htpasswd"
+        self.path.write_text(APR1_LINE + "\n", encoding="utf-8")
+        self.patcher = patch.object(GATE, "USER_FILES", [self.path])
+        self.patcher.start()
+
+    def tearDown(self):
+        self.patcher.stop()
+        self.tmp.cleanup()
+
+    def test_apr1_reproduces_the_stored_digest(self):
+        stored = APR1_LINE.split(":", 1)[1]
+        salt = stored.split("$")[2].encode("ascii")
+        self.assertEqual(GATE.apr1_hash(b"correct-horse", salt), stored)
+
+    def test_correct_password_is_accepted(self):
+        self.assertTrue(GATE.check_credentials("demo", "correct-horse"))
+
+    def test_wrong_password_is_rejected(self):
+        self.assertFalse(GATE.check_credentials("demo", "correct-horse "))
+        self.assertFalse(GATE.check_credentials("demo", "wrong"))
+
+    def test_unknown_user_is_rejected(self):
+        self.assertFalse(GATE.check_credentials("nobody", "correct-horse"))
+
+    def test_malformed_user_names_are_rejected_without_reading_files(self):
+        for name in ("", "demo:extra", "demo\nadmin"):
+            self.assertFalse(GATE.check_credentials(name, "correct-horse"))
+
+    def test_missing_credential_file_is_not_fatal(self):
+        with patch.object(GATE, "USER_FILES", [Path(self.tmp.name) / "absent"]):
+            self.assertFalse(GATE.check_credentials("demo", "correct-horse"))
+
+
+class Sessions(unittest.TestCase):
+    def test_issued_token_round_trips(self):
+        self.assertEqual(GATE.verify_token(GATE.issue_token("demo")), "demo")
+
+    def test_expired_token_is_rejected(self):
+        self.assertIsNone(GATE.verify_token(GATE.issue_token("demo", ttl=-1)))
+
+    def test_tampered_payload_is_rejected(self):
+        token = GATE.issue_token("demo")
+        body, _, signature = token.partition(".")
+        forged = GATE.base64.urlsafe_b64encode(b"admin|99999999999").decode().rstrip("=")
+        self.assertIsNone(GATE.verify_token(f"{forged}.{signature}"))
+
+    def test_token_signed_with_another_secret_is_rejected(self):
+        token = GATE.issue_token("demo")
+        with patch.object(GATE, "SECRET", b"a-different-secret"):
+            self.assertIsNone(GATE.verify_token(token))
+
+    def test_garbage_is_rejected(self):
+        for value in ("", "no-dot", "a.b", "....", "%%%.%%%"):
+            self.assertIsNone(GATE.verify_token(value))
+
+
+class RedirectSafety(unittest.TestCase):
+    def test_same_site_paths_are_kept(self):
+        self.assertEqual(GATE.safe_next("/qira-benchmark/"), "/qira-benchmark/")
+        self.assertEqual(GATE.safe_next("/?industry=notebook"), "/?industry=notebook")
+
+    def test_off_site_targets_fall_back_to_the_portal_home(self):
+        for value in (None, "", "https://malicious.example", "//malicious.example",
+                      "/\\malicious.example", "javascript:alert(1)"):
+            self.assertEqual(GATE.safe_next(value), "/")
+
+    def test_login_routes_do_not_redirect_to_themselves(self):
+        self.assertEqual(GATE.safe_next("/portal-login?next=/"), "/")
+        self.assertEqual(GATE.safe_next("/portal-logout"), "/")
+
+
+class HttpSurface(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp = tempfile.TemporaryDirectory()
+        path = Path(cls.tmp.name) / ".htpasswd"
+        path.write_text(APR1_LINE + "\n", encoding="utf-8")
+        cls.files_patch = patch.object(GATE, "USER_FILES", [path])
+        cls.files_patch.start()
+        cls.delay_patch = patch.object(GATE, "FAILURE_DELAY_SECONDS", 0)
+        cls.delay_patch.start()
+        cls.server = ThreadingHTTPServer(("127.0.0.1", 0), GATE.Handler)
+        cls.server.daemon_threads = True
+        cls.port = cls.server.server_address[1]
+        threading.Thread(target=cls.server.serve_forever, daemon=True).start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.shutdown()
+        cls.server.server_close()
+        cls.delay_patch.stop()
+        cls.files_patch.stop()
+        cls.tmp.cleanup()
+
+    def request(self, method, path, body=None, headers=None):
+        conn = http.client.HTTPConnection("127.0.0.1", self.port, timeout=20)
+        head = dict(headers or {})
+        if body is not None:
+            head.setdefault("Content-Type", "application/x-www-form-urlencoded")
+        conn.request(method, path, body=body, headers=head)
+        response = conn.getresponse()
+        payload = response.read().decode("utf-8", errors="replace")
+        result = (response.status, dict(response.getheaders()), payload)
+        conn.close()
+        return result
+
+    def sign_in(self, user="demo", password="correct-horse", next_url="/qira-benchmark/"):
+        return self.request(
+            "POST", "/portal-login",
+            body=f"username={user}&password={password}&next={next_url}",
+        )
+
+    def test_auth_endpoint_rejects_an_anonymous_request(self):
+        status, _, _ = self.request("GET", "/portal-auth")
+        self.assertEqual(status, 401)
+
+    def test_login_page_is_served_without_a_session(self):
+        status, headers, body = self.request("GET", "/portal-login?next=/qira-benchmark/")
+        self.assertEqual(status, 200)
+        self.assertIn("text/html", headers["Content-Type"])
+        self.assertIn('name="password"', body)
+        self.assertIn("clawpilotTheme", body)
+        self.assertIn("--cp-bg: #f7f4ef", body)
+
+    def test_successful_sign_in_sets_a_guarded_cookie_and_redirects(self):
+        status, headers, _ = self.sign_in()
+        self.assertEqual(status, 303)
+        self.assertEqual(headers["Location"], "/qira-benchmark/")
+        cookie = headers["Set-Cookie"]
+        self.assertIn("portal_session=", cookie)
+        self.assertIn("HttpOnly", cookie)
+        self.assertIn("SameSite=Lax", cookie)
+        self.assertIn("Path=/", cookie)
+
+    def test_session_cookie_satisfies_the_auth_endpoint(self):
+        _, headers, _ = self.sign_in()
+        token = headers["Set-Cookie"].split(";", 1)[0]
+        status, _, _ = self.request("GET", "/portal-auth", headers={"Cookie": token})
+        self.assertEqual(status, 204)
+
+    def test_failed_sign_in_redisplays_the_form_without_a_cookie(self):
+        status, headers, body = self.sign_in(password="wrong")
+        self.assertEqual(status, 401)
+        self.assertNotIn("Set-Cookie", headers)
+        self.assertIn("did not match", body)
+
+    def test_off_site_next_is_neutralised_on_success(self):
+        _, headers, _ = self.sign_in(next_url="https://malicious.example")
+        self.assertEqual(headers["Location"], "/")
+
+    def test_logout_clears_the_cookie(self):
+        status, headers, _ = self.request("GET", "/portal-logout")
+        self.assertEqual(status, 302)
+        self.assertIn("Max-Age=0", headers["Set-Cookie"])
+
+    def test_forged_cookie_does_not_authenticate(self):
+        status, _, _ = self.request(
+            "GET", "/portal-auth", headers={"Cookie": "portal_session=forged.value"})
+        self.assertEqual(status, 401)
+
+    def test_unknown_route_is_a_404(self):
+        self.assertEqual(self.request("GET", "/nope")[0], 404)
+        self.assertEqual(self.request("POST", "/nope", body="x=1")[0], 404)
+
+
+class Packaging(unittest.TestCase):
+    def test_gate_compiles(self):
+        result = subprocess.run(
+            ["python", "-m", "py_compile", str(GATE_PATH)],
+            capture_output=True, text=True)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_deployment_files_are_shipped(self):
+        deploy = GATE_PATH.parent
+        for name in ("portal-gate.service", "nginx-portal-gate.conf"):
+            self.assertTrue((deploy / name).is_file(), name)
+
+    def test_nginx_snippet_documents_the_auth_request_switch(self):
+        conf = (GATE_PATH.parent / "nginx-portal-gate.conf").read_text(encoding="utf-8")
+        self.assertIn("auth_request /portal-auth;", conf)
+        self.assertIn("error_page 401 = @portal_signin;", conf)
+        self.assertIn("location = /portal-login", conf)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Agents/AOAI-Model-Migration-Benchmark/qira-live-benchmark-console/tests/test_portal_gate.py
+++ b/Agents/AOAI-Model-Migration-Benchmark/qira-live-benchmark-console/tests/test_portal_gate.py
@@ -148,6 +148,12 @@ class RedirectSafety(unittest.TestCase):
                       "/ok\rX-Injected: 1", "/ok\x00", "/ok\x7f"):
             self.assertEqual(GATE.safe_next(value), "/")
 
+    def test_a_trailing_newline_does_not_slip_past_the_allowlist(self):
+        # Python's `$` also matches before a trailing newline, so the pattern
+        # must be anchored with \Z or "/foo\n" would be accepted.
+        for value in ("/foo\n", "/\n", "/a/b/\n"):
+            self.assertEqual(GATE.safe_next(value), "/")
+
     def test_only_valid_url_path_characters_are_accepted(self):
         for value in ("/a b", "/tab\there", "/quote\"x", "/angle<x>", "/back\\slash"):
             self.assertEqual(GATE.safe_next(value), "/")

--- a/Agents/AOAI-Model-Migration-Benchmark/qira-live-benchmark-console/tests/test_portal_gate.py
+++ b/Agents/AOAI-Model-Migration-Benchmark/qira-live-benchmark-console/tests/test_portal_gate.py
@@ -10,7 +10,6 @@ import unittest
 from http.server import ThreadingHTTPServer
 from pathlib import Path
 from unittest.mock import patch
-
 GATE_PATH = Path(__file__).resolve().parents[1] / "deploy" / "portal-gate" / "gate.py"
 _SECRET_DIR = tempfile.TemporaryDirectory()
 os.environ.setdefault("PORTAL_GATE_SECRET", str(Path(_SECRET_DIR.name) / "secret"))
@@ -61,6 +60,50 @@ class Apr1Verification(unittest.TestCase):
             self.assertFalse(GATE.check_credentials("demo", "correct-horse"))
 
 
+class HtpasswdDelegation(unittest.TestCase):
+    """Non-apr1 entries are delegated; the password must stay off the argv."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.path = Path(self.tmp.name) / ".htpasswd"
+        # A bcrypt-looking entry forces the delegated branch.
+        self.path.write_text("bcryptuser:$2y$05$abcdefghijklmnopqrstuv\n", encoding="utf-8")
+        self.patcher = patch.object(GATE, "USER_FILES", [self.path])
+        self.patcher.start()
+
+    def tearDown(self):
+        self.patcher.stop()
+        self.tmp.cleanup()
+
+    def test_password_is_piped_on_stdin_not_passed_as_an_argument(self):
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            captured["input"] = kwargs.get("input")
+            return subprocess.CompletedProcess(cmd, 0)
+
+        with patch.object(GATE.shutil, "which", return_value="/usr/bin/htpasswd"), \
+                patch.object(GATE.subprocess, "run", fake_run):
+            self.assertTrue(GATE.check_credentials("bcryptuser", "s3cr3t-value"))
+
+        self.assertIn("-vi", captured["cmd"])
+        self.assertNotIn("-vb", captured["cmd"])
+        self.assertEqual(captured["input"], b"s3cr3t-value")
+        # /proc/<pid>/cmdline exposes argv to every local account.
+        self.assertNotIn("s3cr3t-value", captured["cmd"])
+
+    def test_a_nonzero_exit_is_a_rejected_password(self):
+        with patch.object(GATE.shutil, "which", return_value="/usr/bin/htpasswd"), \
+                patch.object(GATE.subprocess, "run",
+                             lambda cmd, **kw: subprocess.CompletedProcess(cmd, 1)):
+            self.assertFalse(GATE.check_credentials("bcryptuser", "wrong"))
+
+    def test_a_missing_htpasswd_binary_rejects_rather_than_crashes(self):
+        with patch.object(GATE.shutil, "which", return_value=None):
+            self.assertFalse(GATE.check_credentials("bcryptuser", "anything"))
+
+
 class Sessions(unittest.TestCase):
     def test_issued_token_round_trips(self):
         self.assertEqual(GATE.verify_token(GATE.issue_token("demo")), "demo")
@@ -105,6 +148,13 @@ class RedirectSafety(unittest.TestCase):
                       "/ok\rX-Injected: 1", "/ok\x00", "/ok\x7f"):
             self.assertEqual(GATE.safe_next(value), "/")
 
+    def test_only_valid_url_path_characters_are_accepted(self):
+        for value in ("/a b", "/tab\there", "/quote\"x", "/angle<x>", "/back\\slash"):
+            self.assertEqual(GATE.safe_next(value), "/")
+        for value in ("/qira-benchmark/api/catalog?run_id=abc123",
+                      "/path_with.dots~and-dashes/", "/a%20b", "/x?y=1&z=2"):
+            self.assertEqual(GATE.safe_next(value), value)
+
 
 class SecretFile(unittest.TestCase):
     def test_secret_is_created_private_without_a_permissions_window(self):
@@ -134,7 +184,7 @@ class HttpSurface(unittest.TestCase):
         path.write_text(APR1_LINE + "\n", encoding="utf-8")
         cls.files_patch = patch.object(GATE, "USER_FILES", [path])
         cls.files_patch.start()
-        cls.delay_patch = patch.object(GATE, "FAILURE_DELAY_SECONDS", 0)
+        cls.delay_patch = patch.object(GATE, "FAILURE_DEADLINE_SECONDS", 0)
         cls.delay_patch.start()
         cls.server = ThreadingHTTPServer(("127.0.0.1", 0), GATE.Handler)
         cls.server.daemon_threads = True

--- a/Agents/AOAI-Model-Migration-Benchmark/qira-live-benchmark-console/tests/test_portal_gate.py
+++ b/Agents/AOAI-Model-Migration-Benchmark/qira-live-benchmark-console/tests/test_portal_gate.py
@@ -98,6 +98,33 @@ class RedirectSafety(unittest.TestCase):
         self.assertEqual(GATE.safe_next("/portal-login?next=/"), "/")
         self.assertEqual(GATE.safe_next("/portal-logout"), "/")
 
+    def test_control_characters_cannot_reach_a_response_header(self):
+        # parse_qs decodes %0d%0a, so a smuggled CRLF would otherwise be
+        # written straight into the Location header and split the response.
+        for value in ("/ok\r\nX-Injected: 1", "/ok\nX-Injected: 1",
+                      "/ok\rX-Injected: 1", "/ok\x00", "/ok\x7f"):
+            self.assertEqual(GATE.safe_next(value), "/")
+
+
+class SecretFile(unittest.TestCase):
+    def test_secret_is_created_private_without_a_permissions_window(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "nested" / "portal-gate.secret"
+            with patch.object(GATE, "SECRET_PATH", target):
+                secret = GATE.load_secret()
+            self.assertTrue(secret)
+            self.assertTrue(target.is_file())
+            if os.name == "posix":
+                self.assertEqual(target.stat().st_mode & 0o777, 0o600)
+
+    def test_existing_secret_is_reused(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "portal-gate.secret"
+            with patch.object(GATE, "SECRET_PATH", target):
+                first = GATE.load_secret()
+                second = GATE.load_secret()
+            self.assertEqual(first, second)
+
 
 class HttpSurface(unittest.TestCase):
     @classmethod
@@ -177,6 +204,20 @@ class HttpSurface(unittest.TestCase):
     def test_off_site_next_is_neutralised_on_success(self):
         _, headers, _ = self.sign_in(next_url="https://malicious.example")
         self.assertEqual(headers["Location"], "/")
+
+    def test_crlf_in_next_cannot_split_the_redirect_response(self):
+        status, headers, body = self.sign_in(next_url="/ok%0d%0aX-Injected:%201")
+        self.assertEqual(status, 303)
+        self.assertEqual(headers["Location"], "/")
+        self.assertNotIn("X-Injected", headers)
+        self.assertNotIn("X-Injected", body)
+
+    def test_crlf_in_a_login_page_request_is_not_reflected(self):
+        status, headers, body = self.request(
+            "GET", "/portal-login?next=/ok%0d%0aX-Injected:%201")
+        self.assertEqual(status, 200)
+        self.assertNotIn("X-Injected", headers)
+        self.assertNotIn("X-Injected", body)
 
     def test_logout_clears_the_cookie(self):
         status, headers, _ = self.request("GET", "/portal-logout")


### PR DESCRIPTION
## Summary

Replaces the browser's Basic-Auth credential dialog on the Linux Work VM Demo Portal with an in-page, themed sign-in screen.

nginx still enforces access, but through `auth_request` against a small local service on `127.0.0.1:8515`:

```text
anonymous -> nginx auth_request -> 401 -> 302 /portal-login (themed form)
signed in -> nginx auth_request -> 204 -> portal home or any proxied app
```

- Credentials are verified against the **same htpasswd files nginx already used**, so existing portal passwords keep working and nobody is locked out. Apache `apr1` hashes are verified in pure Python; bcrypt entries are delegated to the system `htpasswd` binary.
- A successful sign-in issues an HMAC-SHA256 session cookie that is `HttpOnly`, `SameSite=Lax`, and time limited. One sign-in covers the portal home page and every proxied application.
- `next` targets are restricted to same-site paths, so the form cannot become an open redirect.
- Failed sign-ins take a constant delay and never reveal whether the user name exists.
- The login page reuses the portal's light theme and adapts to dark mode.

## Validation

- Gate test suite: 26 tests. The `apr1` fixture is generated by Apache's own `htpasswd -nbm`, so the pure-Python implementation is checked against an independent reference rather than itself.
- Full console suite including the gate: **106 tests passed**.
- Replay pack verified: 4 runs, 29 arm summaries.
- On the VM, before switching nginx: `apr1` accepted the correct password (303) and rejected a wrong one (401); the live bcrypt credential authenticated and its cookie satisfied `/portal-auth` (204).
- After switching: `/`, `/qira-benchmark/`, `/qira-benchmark/api/catalog` and `/mxc-routing/` all return **302 to the login form**, and the `WWW-Authenticate` popup header is gone. `/portal-login` stays public (200).
- Browser end-to-end: signed in through the form, landed on the portal home, opened the Qira console with **no dialog** (`dialogFired=false`).
- A real paid benchmark ran through the gate: TTFT 1470.7 ms, 75 in / 21 out tokens, no error, 5 SSE events, history 2 -> 3, so streaming and run history are unaffected.
- Logout clears the cookie (`Max-Age=0`).

`nginx-default.deployed.conf` records the configuration now running on the Work VM; the previous config is kept on the VM at `/etc/nginx/backups/default.pre-portal-gate`.